### PR TITLE
Update Python requirement to 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,14 +7,14 @@ authors = [
 ]
 readme = "README.md"
 license = {text = "MIT"}
-requires-python = ">=3.13"
+requires-python = ">=3.11"
 keywords = ["birding", "travel", "ebird", "recommendations", "llm", "pocketflow"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: End Users/Desktop",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Scientific/Engineering",
     "Topic :: Other/Nonlisted Topic",
 ]


### PR DESCRIPTION
## Summary
- set minimum supported Python to 3.11
- update classifiers for Python 3.11

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bird_travel_recommender')*

------
https://chatgpt.com/codex/tasks/task_e_684f551e0d74832b8a3ab0c80f8df6e5