### PR TITLE
Update pytest path handling

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -22,3 +22,4 @@ markers =
 filterwarnings =
     ignore::DeprecationWarning
     ignore::PendingDeprecationWarning
+pythonpath = src

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,12 @@ from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 import json
 import os
+import sys
+from pathlib import Path
 from typing import Dict, List, Any
+
+# Add the src directory to the Python path so tests can import the package
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- ensure `src` is on the Python path for tests
- configure pytest to include the `src` directory

## Testing
- `pytest --collect-only -q`

------
https://chatgpt.com/codex/tasks/task_e_684f55e787fc832b8519f3a55083a137