### PR TITLE
Remove committed auth secret and update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ __pycache__/
 config/auth_config.json
 config/*.json
 !config/*.example.json
+config/.auth_secret
 
 # IDE - VSCode
 .vscode/*

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -23,6 +23,10 @@ cp .env.example .env
 # Edit .env file with your API keys
 # OPENAI_API_KEY=your_openai_key_here
 # EBIRD_API_KEY=your_ebird_key_here
+
+# Generate the authentication secret
+mkdir -p config
+openssl rand -hex 32 > config/.auth_secret
 ```
 
 ### 2. Deploy MCP Server

--- a/config/.auth_secret
+++ b/config/.auth_secret
@@ -1,1 +1,0 @@
-v4WC1QrocAaig9uJFZj301vp-5Q8XF6_i1DKAeQtHUg


### PR DESCRIPTION
## Summary
- remove `config/.auth_secret` from version control
- ignore `/config/.auth_secret`
- document generating an auth secret during deployment setup

## Testing
- `uv run pytest -q` *(fails: Failed to fetch https://pypi.org/simple/pytest/)*

------
https://chatgpt.com/codex/tasks/task_e_684f5888d97c832ba44c26bb27a77a5e