### PR TITLE
Mask dev API key in logs

### DIFF
--- a/src/bird_travel_recommender/mcp/auth.py
+++ b/src/bird_travel_recommender/mcp/auth.py
@@ -147,7 +147,9 @@ class AuthManager:
         self._save_api_keys()
         
         logger.info(f"Created development API key: {key_id}")
-        logger.info(f"Raw key (save this): {raw_key}")
+        # Avoid logging the full secret; mask most characters for reference
+        masked_key = raw_key[:4] + "***" + raw_key[-4:]
+        logger.info(f"Raw key (save this): {masked_key}")
         
         return raw_key
     


### PR DESCRIPTION
## Summary
- stop logging the full development API key

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv', FileNotFoundError, ModuleNotFoundError: No module named 'mcp')*

------
https://chatgpt.com/codex/tasks/task_e_684f588a74f0832b9490366d720e3420